### PR TITLE
feat: Pagination support and robust volume/chapter filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-scripts/Output*
+
 scripts/info*
 .github/*.md
 .vscode/*
 docs/!*.md
+**/Output*

--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ Download a specific chapter:
 .\get-chapter.ps1 -ChapterId "{chapter-id}" -ChapterName "Chapter Title"
 ```
 
+### Pagination Support
+
+The script automatically handles MangaDex API pagination for large manga series. When a manga has more chapters than can be returned in a single API response, the script will:
+- Fetch chapters in batches (default: 100 per request)
+- Continue requesting additional pages until all chapters are processed
+- Create output folders and files for each batch, ensuring no chapters are missed
+
+**You do not need to specify any extra parameters for pagination.**
+
+#### Example (no actual manga link shown):
+```powershell
+# Download all chapters for a manga (pagination handled automatically)
+cd scripts
+./get-manga.ps1 -MangaId <manga-id> -MangaName <manga-name> -Language en -TargetFolder ../Output -DryRun
+```
+
+- The script will create multiple `manga-feed-<manga-id>-(en)-(page).json` files and chapter folders as needed.
+- Pagination is transparent to the user; all chapters are processed regardless of total count.
+
 ## Parameters Reference
 
 ### get-manga.ps1 Parameters

--- a/README.md
+++ b/README.md
@@ -199,3 +199,25 @@ This project is available under the terms specified in the [LICENSE](LICENSE) fi
 4. **File Path Issues**: Ensure the target folder path exists and is writable
 
 For more detailed troubleshooting, enable verbose output or use the `-DryRun` parameter to test configurations.
+
+### Volume and Chapter Filtering Details
+
+The script supports advanced filtering using the following parameters:
+- `-VolFrom`: Start from this volume (inclusive)
+- `-VolTo`: End at this volume (inclusive)
+- `-ChapFrom`: Start from this chapter (inclusive)
+- `-ChapTo`: End at this chapter (inclusive)
+
+**How filtering works:**
+- If `-VolFrom` is set, all chapters with a lower volume are skipped.
+- If `-VolTo` is set, all chapters with a higher volume are skipped.
+- If both `-VolFrom` and `-ChapFrom` are set, chapters in the starting volume with a chapter number lower than `-ChapFrom` are skipped.
+- If both `-VolTo` and `-ChapTo` are set, chapters in the ending volume with a chapter number higher than `-ChapTo` are skipped.
+- If only `-ChapFrom` is set (and no `-VolFrom`), chapters in volume 0, 1, or null with a chapter number lower than `-ChapFrom` are skipped. This helps when a manga starts with special/extra volumes.
+
+**Examples:**
+- `-VolFrom 2 -ChapFrom 5`: Only chapters from volume 2, chapter 5 onward (and all later volumes) are included.
+- `-VolTo 10 -ChapTo 3`: Only chapters up to volume 10, chapter 3 (and all earlier volumes) are included.
+- `-ChapFrom 7`: Only chapters 7 and above in volume 0, 1, or null are included (useful for one-shot/specials).
+
+Chapters outside these ranges are automatically skipped during processing.

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -1,18 +1,17 @@
 # Implementation Tasks for mangadex-downloader-ps
 
 ## Completed Stories
-- **Documentation Update** - Updated README.md to properly document all current features, parameters, usage examples, and project roadmap (July 2, 2025)
+- ### Documentation Update
+- [x] Updated README.md to properly document all current features, parameters, usage examples, and project roadmap (July 2, 2025)
 
 ## In Progress Stories
-- None yet
+### Story 01: Pagination Support - Started July 3, 2025
+- [x] Analyze MangaDex API pagination requirements
+- [x] Update scripts to handle paginated API responses
+- [x] Test with large manga series
+- [x] Update documentation with usage examples
 
 ## Planned Stories
-
-### Story 01: Pagination Support
-- [ ] Analyze MangaDex API pagination requirements
-- [ ] Update scripts to handle paginated API responses
-- [ ] Test with large manga series
-- [ ] Update documentation with usage examples
 
 ### Story 02: Advanced Filtering
 - [ ] Research available filtering options in MangaDex API

--- a/docs/implementation-tasks.md
+++ b/docs/implementation-tasks.md
@@ -10,6 +10,7 @@
 - [x] Update scripts to handle paginated API responses
 - [x] Test with large manga series
 - [x] Update documentation with usage examples
+- [x] Implement and document robust volume/chapter filtering (VolFrom, VolTo, ChapFrom, ChapTo) with edge case handling
 
 ## Planned Stories
 

--- a/docs/stories/story01-pagination.md
+++ b/docs/stories/story01-pagination.md
@@ -4,7 +4,8 @@
 As a user, I want the downloader to support pagination so that I can download manga series that span multiple API pages without missing chapters.
 
 ## Tasks
-- [ ] Analyze MangaDex API pagination requirements
-- [ ] Update scripts to handle paginated API responses
-- [ ] Test with large manga series
-- [ ] Update documentation with usage examples
+- [x] Analyze MangaDex API pagination requirements
+- [x] Update scripts to handle paginated API responses
+- [x] Test with large manga series
+- [x] Update documentation with usage examples
+- [x] Implement and document robust volume/chapter filtering (VolFrom, VolTo, ChapFrom, ChapTo) with edge case handling

--- a/scripts/get-manga.ps1
+++ b/scripts/get-manga.ps1
@@ -135,45 +135,17 @@ Do {
 			$chapNum = [int]$item.attributes.chapter
 			$chapStr = "{0:$ChapFormat}" -f $chapNum
 			
-			# hagyd ki ha
-			# ha volfrom meg van adva chapfromot leszarom és a volnum kisebb, mint a volfrom
-			# ha a volfrom nincs megadva, chapfrom megvan adva volnum vagy null vagy 0 vagy 1 (de a három közül csak az elsőre kellene működnie) és chapnum kisebb, mint a chapfrom 
-				# (első találatkor be kellene állítani, melyik opció a három közül?)
-				# (VAGY ez csak az első kötetre érvényes és ha van korábbi null vagy 0 kötet, akkor abból mindent leszedek VAGY ugyanez de ezekből semmit nem szedek le)
-				# # (utóbbi lehet az alap és egy plusz kapcsoló, hogy kellenek-e az extra kötetek 0/null vagy sem)
-			# ha a volfrom meg van adva és a chapfrom is meg van adva, a volnum megegyezik a volfrommal és chapnum kisebb, mint a chapfrom
-			# if (
-				# (
-					# $VolFrom 
-					# -and 
-					# (
-						# $volNum -lt $VolFrom 
-						# -or 
-						# (
-							# $ChapFrom 
-							# -and 
-							# ($VolNum -eq $VolFrom -and $chapNum -lt $ChapFrom)
-							# -and 
-						# )
-					# )
-				# ) 
-				# -or
-				# (
-					# $VolTo 
-					# -and 
-					# (
-						# $VolTo -gt $volNum
-						# -or 
-						# (
-							# $ChapTo
-							# -and 
-							# $ChapTo -gt $chapNum
-						# )
-					# )
-				# )
-			# ) {
-				# continue
-			# }
+			# Filtering logic for VolFrom, VolTo, ChapFrom, ChapTo
+			if (
+				($VolFrom -and $volNum -lt $VolFrom) -or
+				($VolTo -and $volNum -gt $VolTo) -or
+				($VolFrom -and $ChapFrom -and $volNum -eq $VolFrom -and $chapNum -lt $ChapFrom) -or
+				($VolTo -and $ChapTo -and $volNum -eq $VolTo -and $chapNum -gt $ChapTo) -or
+				(-not $VolFrom -and $ChapFrom -and ($volNum -eq 0 -or $volNum -eq 1 -or $volNum -eq $null) -and $chapNum -lt $ChapFrom)
+			) {
+				write-host "Skipping chapter: Volume $volNum, Chapter $chapNum (filtered by range)"
+				continue
+			}
 			
 			$chapterTitlePart = if ($chapterTitle) { " - $chapterTitle" } else { "" }
 			$chapterTargetName = "$($MangaName) v$($volStr)c$($chapStr)$($chapterTitlePart) ($($groupName))"

--- a/scripts/get-manga.ps1
+++ b/scripts/get-manga.ps1
@@ -91,7 +91,8 @@ $limit = 100
 $total = $limit # just to start the loop
 $offset = 0
 
-do {
+# Pagination loop
+Do {
 	$MangaFeedJsonName = "$($CombinedTargetFolder)/manga-feed-$($MangaId)-($($Language))-($($page)).json"
 	write-host "$MangaName feed json: $MangaFeedJsonName"
 
@@ -103,22 +104,19 @@ do {
 		$urlPath="manga/$($MangaId)/feed?limit=$($limit)&translatedLanguage[]=$($Language)&includes[]=scanlation_group&includes[]=user&order[volume]=asc&order[chapter]=asc&offset=$($offset)&contentRating[]=safe&contentRating[]=suggestive&contentRating[]=erotica&contentRating[]=pornographic"
 		$RequestUrl="https://api.mangadex.org/$($urlPath)"
 
-		try
-		{
-			$response = Invoke-RestMethod -UseBasicParsing -Uri $($RequestUrl) 
+		try {
+			$response = Invoke-RestMethod -UseBasicParsing -Uri $($RequestUrl)
 			write-host "OK"
-		}
-		catch
-		{
+		} catch {
 			$StatusCode = $_.Exception.Response.StatusCode.value__
 			write-host "Error"
 		}
 
 		write-host $StatusCode
-
 		$response | ConvertTo-Json -depth 100 | Out-File $MangaFeedJsonName
 	}
-	$total= $response.total
+
+	$total = $response.total
 
 	write-host "foreach on data"
 	foreach($item in $response.data) {
@@ -213,7 +211,7 @@ do {
 		}
 	}
 
-	$page++	
+	$page++
 	$offset += $limit
 	write-host "page: $page - offset: $offset - total: $total"
-} until ($page * $offset -ge $total)
+} while ($offset -lt $total)


### PR DESCRIPTION
## Summary
- Implemented full MangaDex API pagination support in get-manga.ps1, ensuring all chapters are fetched for large manga series.
- Added and documented robust filtering logic for VolFrom, VolTo, ChapFrom, and ChapTo, including edge cases (e.g., Volume 0, null, or special chapters).
- Output now clearly shows when chapters are skipped due to filtering.
- Updated README.md with detailed filtering documentation and usage examples.
- Retrospectively updated implementation-tasks.md and story01-pagination.md to reflect this feature fix and documentation improvements.

## Why
- Ensures users can reliably download all chapters, even for long-running manga.
- Filtering now matches documentation and user expectations, with clear feedback in script output.
- Project history and story tracking accurately reflect this important improvement.